### PR TITLE
pre-commit would not use python in venv

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,8 +1,8 @@
--   id: yapf
-    name: yapf
-    entry: yapf
-    language: python
-    'types': [python]
-    args: ["-i"]
-    require_serial: false
-    additional_dependencies: []
+- id: yapf
+  name: yapf
+  entry: yapf
+  language: system
+  types: [python]
+  args: ["-i"]
+  require_serial: false
+  additional_dependencies: []


### PR DESCRIPTION
ENV: devcontainer in vscode
Issue: pre-commit will not use python in venv
Reason: language property was set to python would run yapf as python module not system command.