### PR TITLE
Add toml as additional dependency

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,4 +5,4 @@
     'types': [python]
     args: ["-i"]
     require_serial: false
-    additional_dependencies: []
+    additional_dependencies: [toml]


### PR DESCRIPTION
Hi all, this PR adds `toml` as a dependency to avoid: 
`yapf: toml package is needed for using pyproject.toml as a configuration file` when the config is specified using a `toml` file.

Closes #15 